### PR TITLE
feat: respect user preferences

### DIFF
--- a/src/client/components/Header/index.tsx
+++ b/src/client/components/Header/index.tsx
@@ -30,11 +30,12 @@ export const Header = (): JSX.Element => {
   return (
     <header className="header">
       <section className="header-left">
-        {isDarkMode ? darkIcon : lightIcon}
+        {lightIcon}
         <label className="switch">
-          <input type="checkbox" onClick={() => toggleDarkMode(isDarkMode)} />
+          <input type="checkbox" onClick={() => toggleDarkMode(isDarkMode)} defaultChecked={isDarkMode} />
           <span className="slider round" />
         </label>
+        {darkIcon}
       </section>
       <section className="header-store">
         <h1>Zustand Store</h1>

--- a/src/client/components/Header/index.tsx
+++ b/src/client/components/Header/index.tsx
@@ -32,7 +32,7 @@ export const Header = (): JSX.Element => {
       <section className="header-left">
         {lightIcon}
         <label className="switch">
-          <input type="checkbox" onClick={() => toggleDarkMode(isDarkMode)} defaultChecked={isDarkMode} />
+          <input type="checkbox" onClick={toggleDarkMode} defaultChecked={isDarkMode} />
           <span className="slider round" />
         </label>
         {darkIcon}

--- a/src/client/store/types.ts
+++ b/src/client/store/types.ts
@@ -24,7 +24,7 @@ export type Store = {
   setHighlightTime: (bool: boolean, idx1: number, idx2: number) => void;
 
   isDarkMode: boolean;
-  toggleDarkMode: (bool: boolean) => void;
+  toggleDarkMode: () => void;
   applyTheme: (bool: boolean) => void;
 
   initialState: {};

--- a/src/client/store/useExtensionStore.ts
+++ b/src/client/store/useExtensionStore.ts
@@ -87,11 +87,13 @@ const useExtensionStore = create<Store>()(
       },
 
       // configures dark mode
-      isDarkMode: window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches,
-      toggleDarkMode: (isDarkMode) => {
-        set({
-          isDarkMode: !isDarkMode,
-        });
+      isDarkMode:
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches,
+      toggleDarkMode: () => {
+        set((state) => ({
+          isDarkMode: !state.isDarkMode,
+        }));
       },
       // Applies the appropriate theme on all divs based on the logic from toggleDarkMode function.
 

--- a/src/client/store/useExtensionStore.ts
+++ b/src/client/store/useExtensionStore.ts
@@ -87,7 +87,7 @@ const useExtensionStore = create<Store>()(
       },
 
       // configures dark mode
-      isDarkMode: false,
+      isDarkMode: window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches,
       toggleDarkMode: (isDarkMode) => {
         set({
           isDarkMode: !isDarkMode,


### PR DESCRIPTION
- This respects the user's dark mode preferences instead of blinding us dark mode users with shining light 🌞 
- Also the two different mode icons are now always shown as the switch moves between those two states. Up for discussion though. Can totally remove that again.

<img width="600" alt="image" src="https://github.com/oslabs-beta/Zukeeper/assets/6306291/453f6b12-53ed-40fb-885b-fba521440dd7">

<img width="600" alt="image" src="https://github.com/oslabs-beta/Zukeeper/assets/6306291/b9d2f0b6-2cfd-40f4-94c5-429ba4af91ca">

